### PR TITLE
changed chunk -> chunkById

### DIFF
--- a/app/Console/Commands/OaiPmhDownloadImages.php
+++ b/app/Console/Commands/OaiPmhDownloadImages.php
@@ -59,7 +59,7 @@ class OaiPmhDownloadImages extends Command
 
         $i = 0;
 
-        Item::where('img_url', '!=', '')->where('has_image', '=', 0)->chunk(200, function ($items) use (&$i) {
+        Item::where('img_url', '!=', '')->where('has_image', '=', 0)->chunkById(200, function ($items) use (&$i) {
             // $items->load('authorities');
             foreach ($items as $item) {
                 if ($item::hasImageForId($item->id) || $this->downloadImage($item)) {


### PR DESCRIPTION
callback was updating table in between 'chunks', affecting filtering b4 chunk
causing half the rows to be skipped. chunkById should solve this problem
because it uses the ids of the rows after filtering to determine chunking
and db update in callback doesn't affect the ids