### PR TITLE
Feature/webumenia 184 cron harvests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file[^1].
 - Searchbar component
 - [Pull Request Template](.github/pull_request_template.md)
 - ZoomController
+- admin-editable cron_status attribute added to SpiceHarvester harvests
+- daily and weekly cron jobs scheduled for harvests with appropriate cron_status 
 
 ### Changed
 - Info section to include MG on map + update current lab.SNG team

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -36,5 +36,15 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command('sitemap:make')->daily();
+        $schedule->call(function() {
+            foreach (\App\SpiceHarvesterHarvest::where('cron_status', '=', 'daily')->get() as $harvest) {
+                App::make('\App\Http\Controllers\SpiceHarvesterController')->launch($harvest->id);
+            }
+        })->daily(); /* daily at midnight */
+        $schedule->call(function() {
+            foreach (\App\SpiceHarvesterHarvest::where('cron_status', '=', 'weekly')->get() as $harvest) {
+                App::make('\App\Http\Controllers\SpiceHarvesterController')->launch($harvest->id);
+            }
+        })->weeklyOn(6, '23:00'); /* sundays at 11pm */
     }
 }

--- a/app/Http/Controllers/SpiceHarvesterController.php
+++ b/app/Http/Controllers/SpiceHarvesterController.php
@@ -159,6 +159,7 @@ class SpiceHarvesterController extends Controller
             // $collection = \Collection::find(Input::get('collection_id'));
             // if ($collection->count()) $harvest->collection()->associate($collection);
             $harvest->collection_id = Input::get('collection_id');
+            $harvest->cron_status = Input::get('cron_status');
             $harvest->save();
 
             Session::flash('message', 'Harvest <code>'.$harvest->set_spec.'</code> bol upravený');

--- a/app/SpiceHarvesterHarvest.php
+++ b/app/SpiceHarvesterHarvest.php
@@ -20,6 +20,8 @@ class SpiceHarvesterHarvest extends Model
 
     protected $appends = array('from');
     public static $datum;
+    public static $cron_statuses = ['manual' => 'Manual', 'daily' => 'Daily', 'weekly' => 'Weekly'];
+    // public static $cron_status;
 
     public static $rules = array(
         'base_url' => 'required',

--- a/database/migrations/2018_06_19_120846_add_cron_status_to_spice_harvester_harvest_table.php
+++ b/database/migrations/2018_06_19_120846_add_cron_status_to_spice_harvester_harvest_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCronAttribute extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('spice_harvester_harvests', function (Blueprint $table) {
+            $table->enum('cron_status', array('manual','daily','weekly'))->default('manual');
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('spice_harvester_harvests', function (Blueprint $table) {
+            $table->dropColumn('status');
+            //
+        });
+    }
+}

--- a/database/migrations/2018_06_19_120846_add_cron_status_to_spice_harvester_harvest_table.php
+++ b/database/migrations/2018_06_19_120846_add_cron_status_to_spice_harvester_harvest_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddCronAttribute extends Migration
+class AddCronStatusToSpiceHarvesterHarvestTable extends Migration
 {
     /**
      * Run the migrations.
@@ -26,7 +26,7 @@ class AddCronAttribute extends Migration
     public function down()
     {
         Schema::table('spice_harvester_harvests', function (Blueprint $table) {
-            $table->dropColumn('status');
+            $table->dropColumn('cron_status');
             //
         });
     }

--- a/resources/views/harvests/form.blade.php
+++ b/resources/views/harvests/form.blade.php
@@ -76,6 +76,12 @@
 	{!! Form::select('collection_id', [null=>'žiadna'] + App\Collection::lists('name','id')->toArray(), Input::old('collection_id'), array('class' => 'form-control')) !!}
 	</div>
 </div>
+<div class="col-md-12">
+	<div class="form-group">
+	{!! Form::label('cron_status', 'Cron Status') !!}
+	{!! Form::select('cron_status', App\SpiceHarvesterHarvest::$cron_statuses, Input::old('cron_status'), array('class' => 'form-control')) !!}
+	</div>
+</div>
 
 <div class="col-md-12 text-center">
 	{!! Form::submit('Uložiť', array('class' => 'btn btn-default')) !!} &nbsp; 

--- a/resources/views/harvests/index.blade.php
+++ b/resources/views/harvests/index.blade.php
@@ -38,6 +38,7 @@ Spice Harvester |
                             <th>Set</th>
                             <th>Metadata Prefix</th>
                             <th>Status</th>
+                            <th>Cron Status</th>
                             <th>Akcie</th>
                         </tr>
                     </thead>
@@ -50,6 +51,7 @@ Spice Harvester |
 			                <td>{!! $h->set_name !!}</td>
 			                <td>{!! $h->metadata_prefix !!}</td>
 			                <td>{!! $h->status . '<br>' . date("d. m. Y h:m",strtotime($h->updated_at)) !!}</td>
+                            <td>{!! $h->cron_status !!}</td>
 			                <td>
                                 {!! Form::open(array('method' => 'DELETE', 'route' => array('harvests.destroy', $h->id), 'class' => 'visible-xs-inline form-inline')) !!}
                                 {!! link_to_action('SpiceHarvesterController@show', 'Detail', array($h->id), array('class' => 'btn btn-primary btn-detail btn-xs btn-outline', )) !!} 


### PR DESCRIPTION
# Description

new field added to spice harvester harvests table -- cron status
options are

- manual (those harvests must be run by a person as and when they need to)
- daily (these harvests will be run automatically at midnight daily)
- weekly (run every week sunday at 11pm)

these are editable by an admin 

Fixes # WEBUMENIA-184

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
