### PR TITLE
Fix authorities search for admin ᕦ(ò_óˇ)ᕤ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- Search endpoint of admin fixed
+
 ### Added
 - Remove query string from localized urls
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -331,6 +331,7 @@ Route::group(['middleware' => ['auth', 'role:admin']], function () {
     Route::get('authority/destroyLink/{link_id}', 'AuthorityController@destroyLink');
     Route::get('authority/reindex', 'AuthorityController@reindex');
     Route::post('authority/destroySelected', 'AuthorityController@destroySelected');
+    Route::get('authority/search', 'AuthorityController@search');
     Route::resource('authority', 'AuthorityController');
     Route::resource('sketchbook', 'SketchbookController');
     Route::resource('slide', 'SlideController');


### PR DESCRIPTION
# Description

For some reason authorities/search had no route
this adds a route for GET requests to <webumeniadomain>/authority/search?search=<searchterm>
still investigating how and when this broke

Fixes #WEBUMENIA-755

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation (n/a)
