### PR TITLE
fix failing image download command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
+### Fixed
+- OAI download command reflects changes to Item model
 
 ## [1.5.2] - 2018-07-27
 ### Fixed
 - Filter color described items in similar by color
-- OAI download command reflects changes to Item model
 
 ## [1.5.1] - 2018-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
 ### Fixed
-- OAI download command reflects changes to Item model
+- download images command
 
 ## [1.5.2] - 2018-07-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file[^1].
 ## [1.5.2] - 2018-07-27
 ### Fixed
 - Filter color described items in similar by color
+- OAI download command reflects changes to Item model
 
 ## [1.5.1] - 2018-07-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
 ### Fixed
-- download images command
+- OAI download images command reflects changes to Item model
 
 ## [1.5.2] - 2018-07-27
 ### Fixed

--- a/app/Console/Commands/OaiPmhDownloadImages.php
+++ b/app/Console/Commands/OaiPmhDownloadImages.php
@@ -46,7 +46,11 @@ class OaiPmhDownloadImages extends Command
      */
     public function fire()
     {
-        $pocet = Item::where('img_url', '!=', '')->where('has_image', '=', 0)->count();
+        // $pocet = Item::where('img_url', '!=', '')->where('has_image', '=', 0)->count();
+        $pocet = Item::whereHas('images', function($q) 
+        {
+            $q->where('img_url', '!=', '');
+        })->where('has_image', '=', 0)->count();
 
         if (! $this->confirm("Naozaj spustit stahovanie obrazkov pre {$pocet} diel? [yes|no]", true)) {
             $this->comment('Tak dovidenia.');
@@ -60,10 +64,13 @@ class OaiPmhDownloadImages extends Command
         $i = 0;
         $failures = 0;
 
-        Item::where('img_url', '!=', '')->where('has_image', '=', 0)->chunkById(200, function ($items) use (&$i, &$failures) {
+        Item::whereHas('images', function($q) 
+        {
+            $q->where('img_url', '!=', '');
+        })->where('has_image', '=', 0)->chunkById(200, function ($items) use (&$i, &$failures) {
             // $items->load('authorities');
             foreach ($items as $item) {
-                if ($item::hasImageForId($item->id) || $this->downloadImage($item)) {
+                if ($item::hasImageForId($item->id) || $this->downloadImages($item)) {
                     $i++;
                     $item->has_image = true;
                     $item->save();
@@ -110,21 +117,26 @@ class OaiPmhDownloadImages extends Command
         );
     }
 
-    private function downloadImage($item)
+    private function downloadImages($item)
     {
-        $file = $item->img_url;
-        try {
-            $data = file_get_contents($file);
-        } catch (\Exception $e) {
-            $this->log->addError($item->img_url . ': ' . $e->getMessage());
-            return false;
-        }
-        
-        $full = true;
-        if ($new_file = $item->getImagePath($full)) {
-            file_put_contents($new_file, $data);
-            return true;
-        }
-        return false;
+        // downloadImages returns false by default
+        $returnBoolean = false;
+        foreach ($item->images() as $image) {
+            $file = $image->$img_url;
+            try {
+                $data = file_get_contents($file);
+            } catch (\Exception $e) {
+                $this->log->addError($image->$img_url . ': ' . $e->getMessage());
+                // end the loop and downloadImages still returns false -- all or nothing
+                break;
+            }
+            $full = true;
+            if ($new_file = $item->getImagePath($full)) {
+                file_put_contents($new_file, $data);
+                // if this succeeds we can return true
+                $returnBoolean = true;
+            }
+        };
+        return $returnBoolean;    
     }
 }

--- a/app/Console/Commands/OaiPmhDownloadImages.php
+++ b/app/Console/Commands/OaiPmhDownloadImages.php
@@ -135,6 +135,6 @@ class OaiPmhDownloadImages extends Command
                 $got_image = true;
             }
         };
-        return $returnBoolean;    
+        return $got_image;    
     }
 }


### PR DESCRIPTION
# Description

oai-pmh:download-images failing because of refactor of Item to Items and ItemImages tables
this fixes the db queries used to reflect these changes

Fixes #WEBUMENIA-752 (link to Jira or GitHub issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
