### PR TITLE
add headings to patternlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file[^1].
 - Multiple item images form in admin
 
 ### Added
+- Headings documented in PatternLib
 - Remove query string from localized urls
 - Use SQLite in tests
 - Dockerfiles for WU to run in docker

--- a/resources/views/components/headings.blade.php
+++ b/resources/views/components/headings.blade.php
@@ -1,0 +1,6 @@
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h3>
+<h4>Heading 4</h4>
+<h5>Heading 5</h5>
+<h6>Heading 6</h6>

--- a/resources/views/components/headings.json
+++ b/resources/views/components/headings.json
@@ -1,0 +1,8 @@
+{
+    "name": "Headings",
+    "data": {
+    },
+    "data_calls" : {
+    },
+    "usage_notes": "The six levels of headings used in text elements. Headings use 'Sentence case', starting with a single uppercase letter, followed by lower case words. 🚧 TODO: fix stepwise fontsize between h1, h2, h3."
+}


### PR DESCRIPTION
# Description

Added six levels of headings (h1 ... h6) as a component to the PatternLib, for documentation purposes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have updated the [CHANGELOG](../CHANGELOG.md)
- [X] I have requested at least 1 reviewer for this PR
- [X] I have made corresponding changes to the documentation
