### PR TITLE
configure gd php extension to use libjpeg before installation of gd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM php:5.6-fpm
 
 RUN apt-get update -y && apt-get install -y \
 	libmcrypt-dev \
-	libpng-dev
+	libpng-dev \
+	libjpeg-dev
 
-RUN docker-php-ext-install \
+RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
+	&& docker-php-ext-install \
 	pdo_mysql \
 	gd \
 	mcrypt \


### PR DESCRIPTION
# Description

adds jpeg support to gd php extension in dockerized php-fpm

Fixes # (link to Jira or GitHub issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have requested at least 1 reviewer for this PR
