### PR TITLE
Feature/khb make bibliography exhibitions and archive translatable

### DIFF
--- a/app/Authority.php
+++ b/app/Authority.php
@@ -29,7 +29,10 @@ class Authority extends Model
         'biography',
         'roles',
         'birth_place',
-        'death_place'
+        'death_place',
+        'bibliography',
+        'exhibitions',
+        'archive',
     ];
 
     // protected $indexName = 'webumenia';

--- a/app/AuthorityTranslation.php
+++ b/app/AuthorityTranslation.php
@@ -7,7 +7,16 @@ use Illuminate\Database\Eloquent\Model;
 class AuthorityTranslation extends Model
 {
     public $timestamps = false;
-    protected $fillable = ['type_organization', 'biography', 'birth_place', 'death_place', 'roles'];
+    protected $fillable = [
+        'type_organization',
+        'biography',
+        'birth_place',
+        'death_place',
+        'roles',
+        'bibliography',
+        'exhibitions',
+        'archive',
+    ];
 
     protected $casts = [
         'roles' => 'array',

--- a/database/migrations/2018_12_17_123411_make_bibliography_exhibitions_and_archive_translatable_attributes_in_authorities.php
+++ b/database/migrations/2018_12_17_123411_make_bibliography_exhibitions_and_archive_translatable_attributes_in_authorities.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeBibliographyExhibitionsAndArchiveTranslatableAttributesInAuthorities extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('authority_translations', function (Blueprint $table) {
+            $table->text('bibliography')->nullable();
+            $table->text('exhibitions')->nullable();
+            $table->text('archive')->nullable();
+        });
+
+        if (!DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+            $default_locale = config('app.locale');
+
+            $authority_data = DB::table('authorities')->get();
+
+            foreach ($authority_data as $authority) {
+                $result = DB::table('authority_translations')
+                    ->where('authority_id', $authority->id)
+                    ->where('locale', $default_locale)
+                    ->update([
+                        'bibliography' => $authority->bibliography,
+                        'exhibitions' => $authority->exhibitions,
+                        'archive' => $authority->archive,
+                    ]);
+            }
+        }
+
+
+        Schema::table('authorities', function (Blueprint $table) {
+            $table->dropColumn([
+                'bibliography',
+                'exhibitions',
+                'archive',
+            ]);
+        });
+
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+        Schema::table('authorities', function ($table) {
+            $table->text('bibliography')->nullable();
+            $table->text('exhibitions')->nullable();
+            $table->text('archive')->nullable();
+        });
+
+        Schema::table('authority_translations', function (Blueprint $table) {
+            $table->dropColumn([
+                'bibliography',
+                'exhibitions',
+                'archive',
+            ]);
+        });
+
+    }
+}

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -65,6 +65,27 @@
                 {{ Form::textarea($locale . "[biography]", isset($authority) ? @$authority->translate($locale)->biography : '', array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
               </div>
 
+              <div class="form-group">
+                  <div class="form-group">
+                    {{ Form::label($locale . "[exhibitions]", 'Zoznam výstav '.strtoupper($locale)) }}
+                    {{ Form::textarea($locale . "[exhibitions]", isset($authority) ? @$authority->translate($locale)->exhibitions : '', array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
+                  </div>
+              </div>
+
+              <div class="form-group">
+                  <div class="form-group">
+                    {{ Form::label($locale . "[bibliography]", 'Bibliografia '.strtoupper($locale)) }}
+                    {{ Form::textarea($locale . "[bibliography]", isset($authority) ? @$authority->translate($locale)->bibliography : '', array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
+                  </div>
+              </div>
+
+              <div class="form-group">
+                  <div class="form-group">
+                    {{ Form::label($locale . "[archive]", 'Archív '.strtoupper($locale)) }}
+                    {{ Form::textarea($locale . "[archive]", isset($authority) ? @$authority->translate($locale)->archive : '', array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
+                  </div>
+              </div>
+
             </div>
             @endforeach
           </div>
@@ -90,30 +111,6 @@
         <div class="form-group">
           {!! Form::label('active_in', 'Miesto pôsobenia') !!}
           {!! Form::text('active_in', Input::old('active_in'), array('class' => 'form-control')) !!}
-        </div>
-      </div>
-      <div class="col-md-12">
-        <div class="form-group">
-            <div class="form-group">
-              {{ Form::label('exhibitions', 'Zoznam výstav') }}
-              {{ Form::textarea('exhibitions', Input::old('exhibitions'), array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
-            </div>
-        </div>
-      </div>
-      <div class="col-md-12">
-        <div class="form-group">
-            <div class="form-group">
-              {{ Form::label('bibliography', 'Bibliografia') }}
-              {{ Form::textarea('bibliography', Input::old('bibliography'), array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
-            </div>
-        </div>
-      </div>
-      <div class="col-md-12">
-        <div class="form-group">
-            <div class="form-group">
-              {{ Form::label('archive', 'Archív') }}
-              {{ Form::textarea('archive', Input::old('archive'), array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
-            </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

After the conversation we decided to use archive, bibliography and exhibitions as translatable attributes.

Migration is also moving the existing - already filled in data.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
