### PR TITLE
add photo_credit field to item form

### DIFF
--- a/app/ItemImage.php
+++ b/app/ItemImage.php
@@ -49,6 +49,6 @@ class ItemImage extends Model
     }
 
     public static function loadValidatorMetadata(ClassMetadata $metadata) {
-        $metadata->addGetterMethodConstraint('iipimg_url', 'getIipimgUrl', new NotBlank());
+        // $metadata->addGetterMethodConstraint('iipimg_url', 'getIipimgUrl', new NotBlank());
     }
 }

--- a/resources/views/items/form.blade.php
+++ b/resources/views/items/form.blade.php
@@ -232,6 +232,13 @@
 	</div>
 
 	<div class="col-md-12">
+		<div class="form-group">
+		{!! Form::label('photo_credit', 'autor fotografie') !!}
+		{!! Form::text('photo_credit', Input::old('photo_credit'), array('class' => 'form-control')) !!}
+		</div>
+	</div>
+
+	<div class="col-md-12">
 		@if(isset($item))
 		<div class="primary-image">
 			aktuálny:<br>


### PR DESCRIPTION
# Description

New field `photo credit` in item form.

And fix for allowing saving edits for items without IIP url.

Fixes WEBUMENIA-856

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [x] I have made corresponding changes to the documentation
