### PR TITLE
Feature/khb theoreticians

### DIFF
--- a/app/Authority.php
+++ b/app/Authority.php
@@ -42,6 +42,7 @@ class Authority extends Model
         'rola' => 'role',
         'príslušnosť' => 'nationality',
         'miesto' => 'place',
+        'typ' => 'type',
     );
 
     public static $sortable = array(
@@ -81,6 +82,11 @@ class Authority extends Model
         'created_at',
         'updated_at',
     );
+
+    protected static $available_types = [
+        'author' => 'umelec',
+        'theoretician' => 'teoretik',
+    ];
 
     protected $with = array('nationalities', 'names');
 
@@ -286,7 +292,7 @@ class Authority extends Model
 
     public function getUrl()
     {
-        return self::detailUrl($this->id);
+        return self::detailUrl($this->id, $this->type);
     }
 
     public function getOaiUrl()
@@ -294,9 +300,10 @@ class Authority extends Model
         return Config::get('app.old_url').'/oai-pmh-new/authority?verb=GetRecord&metadataPrefix=ulan&identifier='.$this->id;
     }
 
-    public static function detailUrl($authority_id)
+    public static function detailUrl($authority_id, $type)
     {
-        return URL::to('autor/'.$authority_id);
+        $type_prefix = self::$available_types[$type];
+        return URL::to($type_prefix.'/'.$authority_id);
     }
 
     public function getDescription($html = false, $links = false, $include_roles = false)
@@ -417,6 +424,7 @@ class Authority extends Model
                 // non-tanslatable attributes:
                 'id' => $this->id,
                 'identifier' => $this->id,
+                'type' => $this->type,
                 'name' => $this->name,
                 'alternative_name' => $this->names->lists('name'),
                 'related_name' => $this->relationships->lists('name'),

--- a/app/Authority.php
+++ b/app/Authority.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Authority extends Model
 {
+    use \Conner\Tagging\Taggable;
     use \Dimsav\Translatable\Translatable, BouncyTrait {
         \Dimsav\Translatable\Translatable::save insteadof BouncyTrait;
     }
@@ -43,6 +44,7 @@ class Authority extends Model
         'príslušnosť' => 'nationality',
         'miesto' => 'place',
         'typ' => 'type',
+        'tagy' => 'tag',
     );
 
     public static $sortable = array(
@@ -232,20 +234,20 @@ class Authority extends Model
         return Cache::get('authority_collections_count');
     }
 
-    public function getTagsAttribute()
-    {
-        if (!Cache::has('authority_tags')) {
-            $tags = $this->join('authority_item', 'authority_item.authority_id', '=', 'authorities.id')
-                            ->join('tagging_tagged', function ($join) {
-                                $join->on('tagging_tagged.taggable_id', '=', 'authority_item.item_id');
-                                $join->on('tagging_tagged.taggable_type', '=', DB::raw("'Item'"));
-                            })->where('authorities.id', '=', $this->id)->groupBy('tagging_tagged.tag_name')->select('tagging_tagged.tag_name', DB::raw('count(tagging_tagged.tag_name) as pocet'))->orderBy('pocet', 'desc')->limit(10)->get();
-            $authority_tags = $tags->lists('tag_name');
-            Cache::put('authority_tags', $authority_tags, 60);
-        }
+    // public function getTagsAttribute()
+    // {
+    //     if (!Cache::has('authority_tags')) {
+    //         $tags = $this->join('authority_item', 'authority_item.authority_id', '=', 'authorities.id')
+    //                         ->join('tagging_tagged', function ($join) {
+    //                             $join->on('tagging_tagged.taggable_id', '=', 'authority_item.item_id');
+    //                             $join->on('tagging_tagged.taggable_type', '=', DB::raw("'Item'"));
+    //                         })->where('authorities.id', '=', $this->id)->groupBy('tagging_tagged.tag_name')->select('tagging_tagged.tag_name', DB::raw('count(tagging_tagged.tag_name) as pocet'))->orderBy('pocet', 'desc')->limit(10)->get();
+    //         $authority_tags = $tags->lists('tag_name');
+    //         Cache::put('authority_tags', $authority_tags, 60);
+    //     }
 
-        return Cache::get('authority_tags');
-    }
+    //     return Cache::get('authority_tags');
+    // }
 
     public function getFormatedNameAttribute()
     {
@@ -426,6 +428,7 @@ class Authority extends Model
                 'id' => $this->id,
                 'identifier' => $this->id,
                 'type' => $this->type,
+                'tag' => $this->tagNames(), // @TODO translate this
                 'name' => $this->name,
                 'alternative_name' => $this->names->lists('name'),
                 'related_name' => $this->relationships->lists('name'),

--- a/app/Authority.php
+++ b/app/Authority.php
@@ -401,9 +401,10 @@ class Authority extends Model
 
     public function index()
     {
-        if ($this->type != 'person') {
-            return false;
-        }
+        // type can be either "author" or "theoretician" and there is no reason to keep this check
+        // if ($this->type != 'person') {
+        //     return false;
+        // }
 
         $client =  $this->getElasticClient();
         $elastic_translatable = \App::make('ElasticTranslatableService');

--- a/app/Authority.php
+++ b/app/Authority.php
@@ -76,6 +76,7 @@ class Authority extends Model
         'bibliography',
         'exhibitions',
         'archive',
+        'studied_at',
     );
 
     protected $dates = array(

--- a/app/Console/Commands/MakeSitemap.php
+++ b/app/Console/Commands/MakeSitemap.php
@@ -124,7 +124,7 @@ class MakeSitemap extends Command
                 if (($model == 'Article' || $model == 'Collection') && (!$entry->publish)) {
                     continue;
                 }
-                if (($model != 'Authority') || ($entry->type == 'person')) { // ak autority, tak len personalne
+                if (($model != 'Authority') || ($entry->type == 'author') || ($entry->type == 'theoretician')) { // ak autority, tak len personalne
                     $images = [];
                     if ($entry->has_image) {
                         $images[] = ['url' => URL::to($entry->getImagePath()), 'title' => $entry->title];

--- a/app/Console/Commands/SetupElasticsearch/cs/authorities.json
+++ b/app/Console/Commands/SetupElasticsearch/cs/authorities.json
@@ -13,6 +13,10 @@
         "type": "string",
         "index": "not_analyzed"
       },
+      "tag": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
       "name": {
         "type": "string",
         "index": "not_analyzed",

--- a/app/Console/Commands/SetupElasticsearch/en/authorities.json
+++ b/app/Console/Commands/SetupElasticsearch/en/authorities.json
@@ -13,6 +13,10 @@
         "type": "string",
         "index": "not_analyzed"
       },
+      "tag": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
       "name": {
         "type": "string",
         "index": "not_analyzed",
@@ -21,7 +25,7 @@
             "type": "string",
             "analyzer": "ascii_folding"
           },
-          "suggest": { 
+          "suggest": {
             "type":     "string",
             "analyzer": "autocomplete",
             "search_analyzer": "ascii_folding"
@@ -36,7 +40,7 @@
             "type": "string",
             "analyzer": "ascii_folding"
           },
-          "suggest": { 
+          "suggest": {
             "type":     "string",
             "analyzer": "autocomplete",
             "search_analyzer": "ascii_folding"
@@ -51,7 +55,7 @@
             "type": "string",
             "analyzer": "ascii_folding"
           },
-          "suggest": { 
+          "suggest": {
             "type":     "string",
             "analyzer": "autocomplete",
             "search_analyzer": "ascii_folding"
@@ -62,7 +66,7 @@
         "type": "string",
         "analyzer": "ascii_folding",
         "fields": {
-          "stemmed": { 
+          "stemmed": {
             "type":     "string",
             "analyzer": "english"
           }

--- a/app/Console/Commands/SetupElasticsearch/sk/authorities.json
+++ b/app/Console/Commands/SetupElasticsearch/sk/authorities.json
@@ -13,6 +13,10 @@
         "type": "string",
         "index": "not_analyzed"
       },
+      "tag": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
       "name": {
         "type": "string",
         "index": "not_analyzed",
@@ -21,7 +25,7 @@
             "type": "string",
             "analyzer": "ascii_folding"
           },
-          "suggest": { 
+          "suggest": {
             "type":     "string",
             "analyzer": "autocomplete",
             "search_analyzer": "ascii_folding"
@@ -36,7 +40,7 @@
             "type": "string",
             "analyzer": "ascii_folding"
           },
-          "suggest": { 
+          "suggest": {
             "type":     "string",
             "analyzer": "autocomplete",
             "search_analyzer": "ascii_folding"
@@ -51,7 +55,7 @@
             "type": "string",
             "analyzer": "ascii_folding"
           },
-          "suggest": { 
+          "suggest": {
             "type":     "string",
             "analyzer": "autocomplete",
             "search_analyzer": "ascii_folding"
@@ -62,7 +66,7 @@
         "type": "string",
         "analyzer": "ascii_folding",
         "fields": {
-          "stemmed": { 
+          "stemmed": {
             "type":     "string",
             "analyzer": "slovencina"
           }

--- a/app/Http/Controllers/AuthorController.php
+++ b/app/Http/Controllers/AuthorController.php
@@ -15,7 +15,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class AuthorController extends ElasticController
 {
 
-    public function getIndex()
+    public function getIndex($authorityType = 'umelci')
     {
         $per_page = 18;
         $page = \Input::get('page', 1);
@@ -38,6 +38,9 @@ class AuthorController extends ElasticController
         $params = array();
         $params["from"] = $offset;
         $params["size"] = $per_page;
+
+        $type = ($authorityType=='teoretici') ? 'theoretician' : 'author';
+        $params["query"]["filtered"]["filter"]["bool"]["must"][]["term"]["type"] = $type;
 
         if ($sort_by=='random') {
             $random = json_decode('

--- a/app/Http/Controllers/AuthorityController.php
+++ b/app/Http/Controllers/AuthorityController.php
@@ -88,7 +88,7 @@ class AuthorityController extends Controller
 
             if (Input::has('tags')) {
                 $authority->reTag(Input::get('tags', []));
-                $authority->index(); //pre istotu. lebo ak sa nic ine nezmeni, tak nepreindexuje
+                $authority->index(); // force reindex - because if nothing else get updated, it wouldn't reindex autmaticaly
             }
 
             if (Input::hasFile('primary_image')) {
@@ -154,7 +154,7 @@ class AuthorityController extends Controller
 
             if (Input::has('tags')) {
                 $authority->reTag(Input::get('tags', []));
-                $authority->index(); //pre istotu. lebo ak sa nic ine nezmeni, tak nepreindexuje
+                $authority->index();  // force reindex - because if nothing else get updated, it wouldn't reindex autmaticaly
             }
 
             // ulozit primarny obrazok. do databazy netreba ukladat. nazov=id

--- a/app/Http/Controllers/AuthorityController.php
+++ b/app/Http/Controllers/AuthorityController.php
@@ -64,7 +64,7 @@ class AuthorityController extends Controller
         $input = Input::all();
 
         $rules = Authority::$rules;
-        // $rules['primary_image'] = 'required|image'; 
+        // $rules['primary_image'] = 'required|image';
 
         $v = Validator::make($input, $rules);
 
@@ -74,11 +74,9 @@ class AuthorityController extends Controller
 
             $authority = new Authority;
 
-            $authority->type = 'person';
-            
             // not sure if OK to fill all input like this before setting translated attributes
             $authority->fill($input);
-            
+
             // store translatable attributes
             foreach (\Config::get('translatable.locales') as $i=>$locale) {
                 foreach ($authority->translatedAttributes as $attribute) {
@@ -195,7 +193,7 @@ class AuthorityController extends Controller
         $authorities = Authority::where('id', 'LIKE', $prefix.'%')->get();
         foreach ($authorities as $key => $authority) {
             $authority_data = $authority->toArray();
-            
+
             $keys = array();
             $values = array();
             foreach ($authority_data as $key => $value) {

--- a/app/Http/Controllers/AuthorityController.php
+++ b/app/Http/Controllers/AuthorityController.php
@@ -86,6 +86,11 @@ class AuthorityController extends Controller
 
             $authority->save();
 
+            if (Input::has('tags')) {
+                $authority->reTag(Input::get('tags', []));
+                $authority->index(); //pre istotu. lebo ak sa nic ine nezmeni, tak nepreindexuje
+            }
+
             if (Input::hasFile('primary_image')) {
                 $this->uploadImage($authority);
             }
@@ -145,6 +150,11 @@ class AuthorityController extends Controller
                         $authority->links()->save($new_link);
                     }
                 }
+            }
+
+            if (Input::has('tags')) {
+                $authority->reTag(Input::get('tags', []));
+                $authority->index(); //pre istotu. lebo ak sa nic ine nezmeni, tak nepreindexuje
             }
 
             // ulozit primarny obrazok. do databazy netreba ukladat. nazov=id

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -266,9 +266,13 @@ function()
     // Route::match(array('GET', 'POST'), 'katalog', 'CatalogController@index');
     // Route::match(array('GET', 'POST'), 'katalog/suggestions', 'CatalogController@getSuggestions');
 
-    Route::match(array('GET', 'POST'), 'autori', 'AuthorController@getIndex');
-    Route::match(array('GET', 'POST'), 'autori/suggestions', 'AuthorController@getSuggestions');
-    Route::get('autor/{id}', 'AuthorController@getDetail');
+    Route::match(array('GET', 'POST'), '{authorityType}', 'AuthorController@getIndex')->where([
+        'authorityType' => 'umelci|teoretici',
+    ]);
+
+    Route::match(array('GET', 'POST'), 'umelci/suggestions', 'AuthorController@getSuggestions');
+    Route::get('umelec/{id}', 'AuthorController@getDetail');
+    Route::get('teoretik/{id}', 'AuthorController@getDetail');
 
     Route::match(array('GET', 'POST'), 'clanky', 'ClanokController@getIndex');
     Route::match(array('GET', 'POST'), 'clanky/suggestions', 'ClanokController@getSuggestions');

--- a/config/tagging.php
+++ b/config/tagging.php
@@ -1,23 +1,23 @@
 <?php
 
 return array(
-    
+
     // Datatype for primary keys of your models.
     // used in migrations only
     'primary_keys_type' => 'integer', // 'string' or 'integer'
-        
+
     // Value of are passed through this before save of tags
     'normalizer' => '\Conner\Tagging\Util::slug',
-    
+
     // Display value of tags are passed through (for front end display)
-    'displayer' => '\Illuminate\Support\Str::title',
-    
+    'displayer' => '\Illuminate\Support\Str::lower',
+
     // Database connection for Conner\Taggable\Tag model to use
 // 	'connection' => 'mysql',
-    
+
     // When deleting a model, remove all the tags first
     'untag_on_delete' => true,
-        
+
     // Auto-delete unused tags from the 'tags' database table (when they are used zero times)
     'delete_unused_tags'=>true,
 

--- a/database/migrations/2018_12_18_095247_change_authority_type_to_author.php
+++ b/database/migrations/2018_12_18_095247_change_authority_type_to_author.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeAuthorityTypeToAuthor extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+            $result = DB::table('authorities')
+                ->where('type', 'person')
+                ->update([
+                    'type' => 'author',
+                ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (!DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+            $result = DB::table('authorities')
+                ->where('type', 'author')
+                ->update([
+                    'type' => 'person',
+                ]);
+        }
+    }
+}

--- a/database/migrations/2018_12_18_120248_add_sudied_at_to_authorities_table.php
+++ b/database/migrations/2018_12_18_120248_add_sudied_at_to_authorities_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSudiedAtToAuthoritiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('authorities', function (Blueprint $table) {
+            $table->string('studied_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('authorities', function (Blueprint $table) {
+            $table->dropColumn([
+                'studied_at',
+            ]);
+
+        });
+    }
+}

--- a/resources/lang/en/autor.php
+++ b/resources/lang/en/autor.php
@@ -32,7 +32,8 @@ return array(
                                   |[2,Inf]show all <strong>:artworks_count</strong> artworks',
 // khb
 
-'biography' => 'Biography',
+'artist_biography' => 'Biography',
+'theoretician_biography' => 'Biography',
 'gallery' => 'Gallery',
 'exhibitions' => 'Exhibitions',
 'bibliography' => 'Bibliography',

--- a/resources/lang/en/autor.php
+++ b/resources/lang/en/autor.php
@@ -18,7 +18,7 @@ return array(
                      |{1}    <strong>:view_count</strong> view
                      |[2,Inf]<strong>:view_count</strong> views',
 
-    'tags'              => 'tags',
+    'tags'              => 'Keywords',
     'back-to-artists'   => 'back to artists page',
     'alternative_names' => 'alternatively',
     'places'            => 'has been active in',
@@ -38,6 +38,10 @@ return array(
 'exhibitions' => 'Exhibitions',
 'bibliography' => 'Bibliography',
 'archive' => 'Archive',
+'birth_year' => 'Birth year',
+'birth_place' => 'Birth place',
+'active_in' => 'Active in',
+'studied_at' => 'Studied at',
 
 // gallery
 

--- a/resources/lang/sk/autor.php
+++ b/resources/lang/sk/autor.php
@@ -20,7 +20,7 @@ return array(
                      |[2,4]  <strong>:view_count</strong> videnia
                      |[5,Inf]<strong>:view_count</strong> videní',
 
-    'tags'              => 'tagy',
+    'tags'              => 'Kľúčové slová',
     'back-to-artists'   => 'zoznam autorov',
     'alternative_names' => 'príp.',
     'places'            => 'Pôsobenie',
@@ -42,6 +42,11 @@ return array(
     'exhibitions' => 'Zoznam výstav',
     'bibliography' => 'Bibliografia',
     'archive' => 'Archív',
+    'birth_year' => 'Dátum narodenia',
+    'birth_place' => 'Miesto narodenia',
+    'active_in' => 'Miesto pôsobenia',
+    'studied_at' => 'Štúdium',
+
 
     // gallery
 

--- a/resources/lang/sk/autor.php
+++ b/resources/lang/sk/autor.php
@@ -36,7 +36,8 @@ return array(
 
     // khb
 
-    'biography' => 'O umelcovi',
+    'artist_biography' => 'O umelcovi',
+    'theoretician_biography' => 'O teoretikovi',
     'gallery' => 'Galéria',
     'exhibitions' => 'Zoznam výstav',
     'bibliography' => 'Bibliografia',

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -143,7 +143,7 @@
       <div class="col-md-12">
         <div class="form-group">
         {!! Form::label('tags', 'tagy') !!}
-        {!! Form::select('tags[]', \Conner\Tagging\Model\Tag::lists('name','name'), (isSet($auhtority)) ? $auhtority->tagNames() : [], ['id' => 'tags', 'multiple' => 'multiple']) !!}
+        {!! Form::select('tags[]', \Conner\Tagging\Model\Tag::lists('name','name'), (isSet($authority)) ? $authority->tagNames() : [], ['id' => 'tags', 'multiple' => 'multiple']) !!}
 
         </div>
       </div>

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -140,6 +140,14 @@
           {!! Form::text('birth_place', Input::old('birth_place'), array('class' => 'form-control')) !!}
         </div>
       </div>
+      <div class="col-md-12">
+        <div class="form-group">
+        {!! Form::label('tags', 'tagy') !!}
+        {!! Form::select('tags[]', \Conner\Tagging\Model\Tag::lists('name','name'), (isSet($auhtority)) ? $auhtority->tagNames() : [], ['id' => 'tags', 'multiple' => 'multiple']) !!}
+
+        </div>
+      </div>
+
     </div>
     <!-- /.panel-body -->
   </div>
@@ -271,6 +279,7 @@
 
 {!! Html::script('js/plugins/bootstrap-slider.min.js') !!}
 {!! Html::script('js/plugins/jquery.cropit.min.js') !!}
+{!! Html::script('js/plugins/selectize.min.js') !!}
 
 <script>
 $(document).ready(function(){
@@ -299,6 +308,13 @@ $(document).ready(function(){
     });
     $('#primary_image').val(imageData);
       return true;
+  });
+
+  $("#tags").selectize({
+    plugins: ['remove_button'],
+    persist: false,
+    create: true,
+    createOnBlur: true
   });
 
 });

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -38,6 +38,15 @@
             </div>
           </div>
         @endif
+
+        <div class="col-md-12">
+          <div class="form-group">
+            {!! Form::label('type', 'typ autority') !!}
+            {!! Form::select('type', ['author' => 'author', 'theoretician' => 'theoretician'], Input::old('type'), array('class' => 'form-control')) !!}
+
+          </div>
+        </div>
+
         <div class="col-md-12">
           <div class="form-group">
             {!! Form::label('name', 'celé meno (Priezvisko, Meno)') !!}

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -122,6 +122,12 @@
           {!! Form::text('active_in', Input::old('active_in'), array('class' => 'form-control')) !!}
         </div>
       </div>
+      <div class="col-md-12">
+        <div class="form-group">
+          {!! Form::label('studied_at', 'Štúdium') !!}
+          {!! Form::text('studied_at', Input::old('studied_at'), array('class' => 'form-control')) !!}
+        </div>
+      </div>
     </div>
     <!-- /.panel-body -->
   </div>

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -128,6 +128,18 @@
           {!! Form::text('studied_at', Input::old('studied_at'), array('class' => 'form-control')) !!}
         </div>
       </div>
+      <div class="col-md-6">
+        <div class="form-group">
+          {!! Form::label('birth_year', 'Dátum narodenia (rok)') !!}
+          {!! Form::text('birth_year', Input::old('birth_year'), array('class' => 'form-control')) !!}
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="form-group">
+          {!! Form::label('birth_place', 'Miesto narodenia') !!}
+          {!! Form::text('birth_place', Input::old('birth_place'), array('class' => 'form-control')) !!}
+        </div>
+      </div>
     </div>
     <!-- /.panel-body -->
   </div>

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -36,7 +36,7 @@
                 </div></div>
                 <p class="my-4">
                     Dátum narodenia <br>
-                    {{ $author->birth_date }}
+                    {{ $author->birth_year }}
                 </p>
                 <p class="my-4">
                     Miesto narodenia  <br>

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -72,7 +72,7 @@
 
                 <div class="accordion" id="authorAccordion">
                     @include('components.khb_accordion_card', [
-                        'title' => utrans('autor.biography'),
+                        'title' => ($author->type == 'theoretician') ? utrans('autor.theoretician_biography') : utrans('autor.artist_biography'),
                         'content' => $author->biography,
                         'parrentId' => 'authorAccordion',
                         'show' => true,

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -34,14 +34,39 @@
                 <div class="row"><div class="col p-0 border-left-0 border-right-0">
                     <img src="{!! $author->getImagePath() !!}" class="img-fluid" alt="{!! $author->name !!}"  itemprop="image">
                 </div></div>
-                <p class="my-4">
-                    Dátum narodenia <br>
-                    {{ $author->birth_year }}
-                </p>
-                <p class="my-4">
-                    Miesto narodenia  <br>
-                    {{ $author->birth_place }}
-                </p>
+                @if ($author->birth_year)
+                    <p class="my-4">
+                        {{ trans('autor.birth_year') }} <br>
+                        {{ $author->birth_year }}
+                    </p>
+                @endif
+                @if ($author->birth_place)
+                    <p class="my-4">
+                        {{ trans('autor.birth_place') }} <br>
+                        {{ $author->birth_place }}
+                    </p>
+                @endif
+                @if ($author->active_in)
+                    <p class="my-4">
+                        {{ trans('autor.active_in') }} <br>
+                        {{ $author->active_in }}
+                    </p>
+                @endif
+                @if ($author->studied_at)
+                    <p class="my-4">
+                        {{ trans('autor.studied_at') }} <br>
+                        {{ $author->studied_at }}
+                    </p>
+                @endif
+                @if (!empty($author->tagNames()))
+                    <p class="my-4">
+                        {{ trans('autor.tags') }} <br>
+                        @foreach ($author->tagNames() as $tag)
+                            <a href="{!!URL::to('katalog?tag=' . $tag)!!}" class="mr-1">#{!! $tag !!}</a>
+                        @endforeach
+                    </p>
+                @endif
+                {{--
                 @if ( $author->events->count() > 0)
                     <div class="events">
                         {{ utrans('autor.places') }}<br>
@@ -50,20 +75,12 @@
                         @endforeach
                     </div>
                 @endif
+                 --}}
                 @if ( $author->links->count() > 0)
                     <div class="links">
                         {{ utrans('autor.links') }}<br>
                         @foreach ($author->links as $i=>$link)
                             <a href="{{ $link->url }}" target="_blank">{{ $link->label }}</a><br>
-                        @endforeach
-                    </div>
-                @endif
-
-                @if ( $author->tags->count() > 0)
-                    <div class="tags">
-                        <h4>{{ utrans('autor.tags') }}: </h4>
-                        @foreach ($author->tags as $tag)
-                            <a href="{!!URL::to('katalog?tag=' . $tag)!!}" class="btn btn-default btn-xs btn-outline">{!! $tag !!}</a>
                         @endforeach
                     </div>
                 @endif

--- a/resources/views/components/khb_nav_bar.blade.php
+++ b/resources/views/components/khb_nav_bar.blade.php
@@ -17,8 +17,8 @@
         </div>
     </div>
     <div class="row">
-        <div class="col grid-cell-link {!! (Request::is('autori') || Request::is('autor/*')) ? 'active' : '' !!}">
-            <a href="{{{ URL::to('autori') }}}" class="">
+        <div class="col grid-cell-link {!! (Request::is('umelci') || Request::is('umelec/*')) ? 'active' : '' !!}">
+            <a href="{{{ URL::to('umelci') }}}" class="">
             </a>
             <span>{{ utrans('master.authors') }}</span>
         </div>
@@ -27,7 +27,7 @@
             </a>
             <span>{{ utrans('master.groups') }}</span>
         </div>
-        <div class="col grid-cell-link {!! Request::is('teoretici') ? 'active' : '' !!}">
+        <div class="col grid-cell-link {!! (Request::is('teoretici') || Request::is('teoretik/*')) ? 'active' : '' !!}">
             <a href="{{{ URL::to('teoretici') }}}" class="">
             </a>
             <span>{{ utrans('master.theoreticians') }}</span>

--- a/resources/views/items/form.blade.php
+++ b/resources/views/items/form.blade.php
@@ -175,7 +175,7 @@
 	<div class="col-md-12">
 		<div class="form-group">
 		{!! Form::label('tags', 'tagy') !!}
-		{!! Form::select('tags[]', App\Item::existingTags()->lists('name','name'), (isSet($item)) ? $item->tagNames() : [], ['id' => 'tags', 'multiple' => 'multiple']) !!}
+		{!! Form::select('tags[]', \Conner\Tagging\Model\Tag::lists('name','name'), (isSet($item)) ? $item->tagNames() : [], ['id' => 'tags', 'multiple' => 'multiple']) !!}
 
 		</div>
 	</div>


### PR DESCRIPTION
# Description

Start using (already existing) authority type: 
- theoretician
- author

Rename the routes (`autori` -> `umelci`)

Adjust admin to be able to edit all authority attributes (both for artists and theoreticians).

Add tags for authors/items. Make them shared.
Using the composer package `rtconner/laravel-tagging`
https://github.com/rtconner/laravel-tagging


Fixes WEBUMENIA-859, WEBUMENIA-876, WEBUMENIA-874, WEBUMENIA-838, 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
