### PR TITLE
Hotfix/1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [1.6.2] - 2019-01-16
 ### Fixed
-- autocomplete for Collections and Articles
+- search autocomplete for Collections and Articles
+- division by zero exception for corrupted images
 
 ## [1.6.1] - 2018-12-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file[^1].
 - search autocomplete for Collections and Articles
 - division by zero exception for corrupted images
 
+### Added
+- 30 days cache to item image headers
+
 ## [1.6.1] - 2018-12-06
 ### Added
 - temporary Christmas alert into order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file[^1].
 ### Fixed
 - search autocomplete for Collections and Articles
 - division by zero exception for corrupted images
+- indexing translated work_type into ElasticSearch
 
 ### Added
 - 30 days cache to item image headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file[^1].
 
 ## [Unreleased]
 
+## [1.6.2] - 2019-01-16
+### Fixed
+- autocomplete for Collections and Articles
+
 ## [1.6.1] - 2018-12-06
 ### Added
 - temporary Christmas alert into order

--- a/app/Http/Controllers/ClanokController.php
+++ b/app/Http/Controllers/ClanokController.php
@@ -24,7 +24,7 @@ class ClanokController extends Controller
     {
         $q = (Input::has('search')) ? str_to_alphanumeric(Input::get('search')) : 'null';
 
-        $result = Article::published()->where('title', 'like', '%'.$q.'%')->limit(5)->get();
+        $result = Article::published()->whereTranslationLike('title', '%'.$q.'%')->limit(5)->get();
 
         $data = array();
         $data['results'] = array();

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -11,9 +11,12 @@ use App\Item;
 class ImageController extends Controller
 {
     protected $max_size_to_fit = 800; // width or height in pixels
+    const SECONDS_TO_CACHE = 2592000; // 30days (60sec * 60min * 24hours * 30days)
 
     public function resize($id, $width, $height=null)
     {
+        $headers = ['Cache-Control' => 'max-age=' . self::SECONDS_TO_CACHE];
+
         if (
             ($width <= $this->max_size_to_fit) &&
             ($height <= $this->max_size_to_fit) &&
@@ -30,7 +33,7 @@ class ImageController extends Controller
 
             $imagePath = public_path() . Item::getImagePathForId($id, false, $resize, $resize_method);
 
-            return response()->file($imagePath);
+            return response()->file($imagePath, $headers);
         }
 
         return App::abort(404);

--- a/app/Http/Controllers/KolekciaController.php
+++ b/app/Http/Controllers/KolekciaController.php
@@ -42,12 +42,12 @@ class KolekciaController extends Controller
     {
         $q = (Input::has('search')) ? str_to_alphanumeric(Input::get('search')) : 'null';
 
-        $result = Collection::published()->where('name', 'like', '%'.$q.'%')->limit(5)->get();
+        $result = Collection::published()->whereTranslationLike('name', '%'.$q.'%')->limit(5)->get();
 
         $data = array();
         $data['results'] = array();
         $data['count'] = 0;
-        
+
         foreach ($result as $key => $hit) {
             $data['count']++;
             $params = array(

--- a/app/Item.php
+++ b/app/Item.php
@@ -363,7 +363,8 @@ class Item extends Model
         if ($full) {
             $result_path = $full_path . "$file.jpeg";
         } else {
-            if (file_exists($full_path . "$file.jpeg")) {
+            // file exist && is valid JPEG file
+            if (file_exists($full_path . "$file.jpeg") && (@exif_imagetype($full_path . "$file.jpeg")==IMAGETYPE_JPEG)) {
                 $result_path =  $relative_path . "$file.jpeg";
 
                 if ($resize) {

--- a/app/Item.php
+++ b/app/Item.php
@@ -570,7 +570,7 @@ class Item extends Model
 
     public function getWorkTypesAttribute()
     {
-        return (explode(', ', $this->work_type));
+        return $this->makeArray($this->work_type, ', ');
     }
 
     public function setLat($value)
@@ -583,13 +583,13 @@ class Item extends Model
         $this->attributes['lng'] = $value ?: null;
     }
 
-    public function makeArray($str)
+    public function makeArray($str, $delimiter = '; ')
     {
         if (is_array($str)) {
             return $str;
         }
         $str = trim($str);
-        return (empty($str)) ? array() : explode('; ', $str);
+        return (empty($str)) ? array() : explode($delimiter, $str);
     }
 
     public static function listValues($attribute, $search_params)
@@ -842,14 +842,13 @@ class Item extends Model
 
             $item_translated = $this->getTranslation($locale);
 
-            $work_types = $item_translated->work_types;
+            $work_types = $this->makeArray($item_translated->work_type, ', ');
             $main_work_type = (is_array($work_types)) ? reset($work_types) : '';
             $data = [
                 // non-tanslatable attributes:
                 'id' => $this->id,
                 'identifier' => $this->identifier,
                 'author' => $this->makeArray($this->author),
-                'work_type' => $main_work_type, // ulozit iba prvu hodnotu
                 'tag' => $this->tagNames(), // @TODO translate this
                 'date_earliest' => $this->date_earliest,
                 'date_latest' => $this->date_latest,
@@ -863,6 +862,7 @@ class Item extends Model
                 'color_descriptor' => $this->color_descriptor,
 
                 // tanslatable attributes:
+                'work_type' => $main_work_type, // ulozit iba prvu hodnotu
                 'title' => $item_translated->title,
                 'description' => (!empty($item_translated->description)) ? strip_tags($item_translated->description) : '',
                 'topic' => $this->makeArray($item_translated->topic),

--- a/resources/views/components/artwork_carousel.blade.php
+++ b/resources/views/components/artwork_carousel.blade.php
@@ -20,7 +20,7 @@
 
     @php
         list($width, $height) = getimagesize(public_path() . $item->getImagePath());
-        $width = $width * ($size / $height);
+        $width = $width * ($size / max($height,1));
         $height = $size;
     @endphp
 

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -52,6 +52,7 @@
                 <div class="col-md-8 text-center">
                         @php
                             list($width, $height) = getimagesize(public_path() . $item->getImagePath());
+                            $width =  max($width,1); // prevent division by zero exception
                         @endphp
 
                         {{-- prevent upsizing by setting max-width to real width --}}
@@ -59,7 +60,7 @@
                             @if ($item->has_iip)
                                 <a href="{{ route('item.zoom', ['id' => $item->id]) }}" data-toggle="tooltip" data-placement="top" title="{{ utrans('general.item_zoom') }}" class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%">
                             @else
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / max($width,1)) * 100, 4) }}%">
+                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%">
                             @endif
 
                                 @include('components.item_image_responsive', [

--- a/resources/views/dielo.blade.php
+++ b/resources/views/dielo.blade.php
@@ -59,7 +59,7 @@
                             @if ($item->has_iip)
                                 <a href="{{ route('item.zoom', ['id' => $item->id]) }}" data-toggle="tooltip" data-placement="top" title="{{ utrans('general.item_zoom') }}" class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%">
                             @else
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%">
+                                <div class="ratio-box" style="padding-bottom: {{ round(($height / max($width,1)) * 100, 4) }}%">
                             @endif
 
                                 @include('components.item_image_responsive', [

--- a/resources/views/katalog.blade.php
+++ b/resources/views/katalog.blade.php
@@ -150,8 +150,9 @@
     	                	<a href="{!! $item->getUrl() !!}">
                                 @php
                                     list($width, $height) = getimagesize(public_path() . $item->getImagePath());
+                                    $width =  max($width,1); // prevent division by zero exception
                                 @endphp
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / max($width,1)) * 100, 4) }}%;">
+                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
     	                		     @include('components.item_image_responsive', ['item' => $item])
                                 </div>
     	                	</a>

--- a/resources/views/katalog.blade.php
+++ b/resources/views/katalog.blade.php
@@ -151,7 +151,7 @@
                                 @php
                                     list($width, $height) = getimagesize(public_path() . $item->getImagePath());
                                 @endphp
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
+                                <div class="ratio-box" style="padding-bottom: {{ round(($height / max($width,1)) * 100, 4) }}%;">
     	                		     @include('components.item_image_responsive', ['item' => $item])
                                 </div>
     	                	</a>

--- a/resources/views/kolekcia.blade.php
+++ b/resources/views/kolekcia.blade.php
@@ -91,7 +91,7 @@
                                 @php
                                     list($width, $height) = getimagesize(public_path() . $item->getImagePath());
                                 @endphp
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
+                                <div class="ratio-box" style="padding-bottom: {{ round(($height / max($width,1)) * 100, 4) }}%;">
 
                                 <img
                                     data-sizes="auto"

--- a/resources/views/kolekcia.blade.php
+++ b/resources/views/kolekcia.blade.php
@@ -90,8 +90,9 @@
                             <a href="{!! $item->getUrl(['collection' => $collection->id]) !!}">
                                 @php
                                     list($width, $height) = getimagesize(public_path() . $item->getImagePath());
+                                    $width =  max($width,1); // prevent division by zero exception
                                 @endphp
-                                <div class="ratio-box" style="padding-bottom: {{ round(($height / max($width,1)) * 100, 4) }}%;">
+                                <div class="ratio-box" style="padding-bottom: {{ round(($height / $width) * 100, 4) }}%;">
 
                                 <img
                                     data-sizes="auto"


### PR DESCRIPTION
# Description

Fix search autocomplete for Collections and Articles after making them translatable.
Fix division by zero exception when counting aspect ratio for corrupted images.
Fix work_type filter in catalogue view.

Fixes WEBUMENIA-888, WEBUMENIA-864, WEBUMENIA-894

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
