### PR TITLE
Feature/webumenia 809 disable prints for non zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file[^1].
 - Remove query string from localized urls
 - Option to launch harvest only for specific record ids
 
+### Removed
+- Printed reproduction options for items without IIP/zoom
+
 ## [1.6.2] - 2019-01-16
 ### Fixed
 - search autocomplete for Collections and Articles

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -66,7 +66,18 @@ function()
 
         $items = Item::with('images')->find(Session::get('cart', array()));
 
-        return view('objednavka', array('items' => $items));
+        $allow_printed_reproductions = true;
+
+        foreach ($items as $item) {
+            if (!$item->hasZoomableImages()) {
+                $allow_printed_reproductions = false;
+            }
+        }
+
+        return view('objednavka', [
+            'items' => $items,
+            'allow_printed_reproductions' => $allow_printed_reproductions,
+        ]);
     });
 
     Route::post('objednavka', function () {

--- a/resources/lang/cs/objednavka.php
+++ b/resources/lang/cs/objednavka.php
@@ -33,8 +33,8 @@ return array(
     'form_format_a3'               => 'do formátu A3+ (35 €/ks)',
     'form_format_for-download'     => 'na stiahnutie:',
     'form_format_digital'          => 'digitálna reprodukcia',
-    'form_purpose-alert'           => 'Autorský zákon nám neumožňuje poskytovať digitálne reprodukcie <abbr title="neprešlo 70 rokov od smrti autora" data-toggle="tooltip">autorsky chránených diel</abbr> na všeobecné súkromné účely (napr. ako dekoráciu). Na základe Vami uvedených informácií vytvorí SNG písomný súhlas s využitím digitálnej reprodukcie iba na predmetný účel &ndash; je to legislatívna ochrana tak pre Vás ako aj pre nás.<br>
-        <strong>V prípade záujmu o tlač výtvarných diel môžete využiť objednávku na tlačenú reprodukciu, kde výrobu a úpravu výtlačku zabezpečuje SNG.</strong>',
+    'form_purpose-alert'           => 'Autorský zákon nám neumožňuje poskytovať digitálne reprodukcie <abbr title="neprešlo 70 rokov od smrti autora" data-toggle="tooltip">autorsky chránených diel</abbr> na všeobecné súkromné účely (napr. ako dekoráciu). Na základe Vami uvedených informácií vytvorí SNG písomný súhlas s využitím digitálnej reprodukcie iba na predmetný účel &ndash; je to legislatívna ochrana tak pre Vás ako aj pre nás.',
+    'form_purpose-alert-print'     => 'V prípade záujmu o tlač výtvarných diel môžete využiť objednávku na tlačenú reprodukciu, kde výrobu a úpravu výtlačku zabezpečuje SNG.',
     'form_purpose-label'           => 'Účel',
     'form_purpose-info'            => 'Účel - podrobnejšie informácie',
     'form_delivery-point'          => 'Miesto osobného odberu',

--- a/resources/lang/en/objednavka.php
+++ b/resources/lang/en/objednavka.php
@@ -37,6 +37,7 @@ return array(
     'form_format_for-download'     => 'For download:',
     'form_format_digital'          => 'digital reproduction',
     'form_purpose-alert'           => 'The copyright law prevents us from providing digital reproductions of <abbr title="less than 70 years has followed the death of the artist" data-toggle="tooltip">copyright protected artworks</abbr> for general private purposes (decoration, gift etc.). Slovak National Gallery will create a written contract, according to the information provided in the order. This contract will limit the use of the reproduction just for the purpose stated in the order.',
+    'form_purpose-alert-print'     => '',
     'form_purpose-label'           => 'Purpose',
     'form_purpose-info'            => 'Purpose description',
     'form_delivery-point'          => 'Pick up location',

--- a/resources/lang/sk/objednavka.php
+++ b/resources/lang/sk/objednavka.php
@@ -15,7 +15,7 @@ return array(
                         <p>K vybraným dielam zo zbierok SNG ponúkame možnosť objednať si reprodukcie v archívnej kvalite na fineartových papieroch. Po výbere diel, vyplnení údajov a odoslaní objednávky vás bude kontaktovať pracovník SNG s podrobnejšími informáciami. Momentálne je možné vyzdvihnúť si diela len osobne v&nbsp;kníhkupectve <a href="https://goo.gl/maps/3Uf4S" target="_blank" class="underline">Ex Libris v priestoroch SNG na Námestí Ľ. Štúra 4 v Bratislave</a>  alebo v pokladni <a href="https://goo.gl/maps/MPRy6Qdwm8s" target="_blank" class="underline">Zvolenského zámku - Námestie SNP 594/1</a>. </p>',
     'order_none'    => 'Nemáte v košíku žiadne diela',
     'order_remove'  => 'odstrániť',
-    'order_warning' => 'Toto dielo momentálne nemáme zdigitalizované v dostatočnej kvalite, vybavenie objednávky preto môže trvať dlhšie ako zvyčajne.',
+    'order_warning' => 'Toto dielo momentálne nemáme zdigitalizované v dostatočnej kvalite, preto nieje možné objednať si tlačenú reprodukciu.',
 
     'form_title'                   => 'Diela objednávky',
     'form_name'                    => 'Meno',
@@ -33,8 +33,8 @@ return array(
     'form_format_a3'               => 'samostatná reprodukcia (35 €/ks)',
     'form_format_for-download'     => 'na stiahnutie:',
     'form_format_digital'          => 'digitálna reprodukcia',
-    'form_purpose-alert'           => 'Autorský zákon nám neumožňuje poskytovať digitálne reprodukcie <abbr title="neprešlo 70 rokov od smrti autora" data-toggle="tooltip">autorsky chránených diel</abbr> na všeobecné súkromné účely (napr. ako dekoráciu). Na základe Vami uvedených informácií vytvorí SNG písomný súhlas s využitím digitálnej reprodukcie iba na predmetný účel &ndash; je to legislatívna ochrana tak pre Vás ako aj pre nás.<br>
-        <strong>V prípade záujmu o tlač výtvarných diel môžete využiť objednávku na tlačenú reprodukciu, kde výrobu a úpravu výtlačku zabezpečuje SNG.</strong>',
+    'form_purpose-alert'           => 'Autorský zákon nám neumožňuje poskytovať digitálne reprodukcie <abbr title="neprešlo 70 rokov od smrti autora" data-toggle="tooltip">autorsky chránených diel</abbr> na všeobecné súkromné účely (napr. ako dekoráciu). Na základe Vami uvedených informácií vytvorí SNG písomný súhlas s využitím digitálnej reprodukcie iba na predmetný účel &ndash; je to legislatívna ochrana tak pre Vás ako aj pre nás.',
+    'form_purpose-alert-print'     => 'V prípade záujmu o tlač výtvarných diel môžete využiť objednávku na tlačenú reprodukciu, kde výrobu a úpravu výtlačku zabezpečuje SNG.',
     'form_purpose-label'           => 'Účel',
     'form_purpose-info'            => 'Účel - podrobnejšie informácie',
     'form_delivery-point'          => 'Miesto osobného odberu',

--- a/resources/views/objednavka.blade.php
+++ b/resources/views/objednavka.blade.php
@@ -80,34 +80,46 @@
 {!! Former::text('email')->label(trans('objednavka.form_email'))->required(); !!}
 {!! Former::text('phone')->label(trans('objednavka.form_phone'))->required(); !!}
 
+@if ($allow_printed_reproductions)
 
-{!! Former::select('format')->label('Formát')->required()->options([
-    trans('objednavka.form_format_for-print_a4') => [
-        'do A4: samostatná reprodukcia 25 €/ks' => [
-            'value'=> trans('objednavka.form_format_standalone') . ' (25 €/'.trans('objednavka.form_piece').')'
+    {!! Former::select('format')->label('Formát')->required()->options([
+        trans('objednavka.form_format_for-print_a4') => [
+            'do A4: samostatná reprodukcia 25 €/ks' => [
+                'value'=> trans('objednavka.form_format_standalone') . ' (25 €/'.trans('objednavka.form_piece').')'
+            ],
+            'do A4: reprodukcia s paspartou 35 €/ks' => [
+                'value'=> trans('objednavka.form_format_with_mounting') . ' (35 €/'.trans('objednavka.form_piece').')'
+            ],
+            'do A4: s paspartou a rámom 40 €/ks' => [
+                'value'=> trans('objednavka.form_format_with_mounting_and_framing') . ' (40 €/'.trans('objednavka.form_piece').')'
+            ],
         ],
-        'do A4: reprodukcia s paspartou 35 €/ks' => [
-            'value'=> trans('objednavka.form_format_with_mounting') . ' (35 €/'.trans('objednavka.form_piece').')'
+        trans('objednavka.form_format_for-print_a3') => [
+            'do A3+: samostatná reprodukcia 35 €/ks' => [
+                'value'=> trans('objednavka.form_format_standalone') . ' (35 €/'.trans('objednavka.form_piece').')'
+            ],
+            'do A3+: reprodukcia s paspartou 50 €/ks' => [
+                'value'=> trans('objednavka.form_format_with_mounting') . ' (50 €/'.trans('objednavka.form_piece').')'
+            ],
+            'do A3+: s paspartou a rámom 60 €/ks' => [
+                'value'=> trans('objednavka.form_format_with_mounting_and_framing') . ' (60 €/'.trans('objednavka.form_piece').')'
+            ],
         ],
-        'do A4: s paspartou a rámom 40 €/ks' => [
-            'value'=> trans('objednavka.form_format_with_mounting_and_framing') . ' (40 €/'.trans('objednavka.form_piece').')'
+        trans('objednavka.form_format_for-download') => [
+                'digitálna reprodukcia' => ['value'=>trans('objednavka.form_format_digital')]
         ],
-    ],
-    trans('objednavka.form_format_for-print_a3') => [
-        'do A3+: samostatná reprodukcia 35 €/ks' => [
-            'value'=> trans('objednavka.form_format_standalone') . ' (35 €/'.trans('objednavka.form_piece').')'
+    ]); !!}
+
+@else
+
+    {!! Former::select('format')->label('Formát')->required()->options([
+        trans('objednavka.form_format_for-download') => [
+                'digitálna reprodukcia' => ['value'=>trans('objednavka.form_format_digital')]
         ],
-        'do A3+: reprodukcia s paspartou 50 €/ks' => [
-            'value'=> trans('objednavka.form_format_with_mounting') . ' (50 €/'.trans('objednavka.form_piece').')'
-        ],
-        'do A3+: s paspartou a rámom 60 €/ks' => [
-            'value'=> trans('objednavka.form_format_with_mounting_and_framing') . ' (60 €/'.trans('objednavka.form_piece').')'
-        ],
-    ],
-    trans('objednavka.form_format_for-download') => [
-            'digitálna reprodukcia' => ['value'=>trans('objednavka.form_format_digital')]
-    ],
-]); !!}
+    ]); !!}
+
+@endif
+
 
 {{-- {!! Former::select('format')->label(trans('objednavka.form_format'))->required()->options(array(
     trans('objednavka.form_format_for-print') => array(
@@ -126,6 +138,9 @@
 <div id="ucel">
     <div class="alert alert-info col-lg-offset-2 col-md-offset-4" role="alert">
         {!! trans('objednavka.form_purpose-alert') !!}
+        @if ($allow_printed_reproductions)
+            <br><strong>{!! trans('objednavka.form_purpose-alert-print') !!}</strong>
+        @endif
     </div>
 {!! Former::select('purpose_kind')->label(trans('objednavka.form_purpose-label'))->required()->options(App\Order::$availablePurposeKinds); !!}
 {!! Former::textarea('purpose')->label(trans('objednavka.form_purpose-info'))->required(); !!}


### PR DESCRIPTION
# Description

The artworks which don't have zoom images won't have the option to order printed reproduction, only digital.

Fixes WEBUMENIA-809

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
