### PR TITLE
Fix/khb-webumenia 880 en missing artist birthplace

### DIFF
--- a/app/Http/Controllers/AuthorityController.php
+++ b/app/Http/Controllers/AuthorityController.php
@@ -13,8 +13,6 @@ use Illuminate\Support\Facades\File;
 use App\SpiceHarvesterRecord;
 use Illuminate\Support\Facades\App;
 
-use Illuminate\Support\Facades\Log;
-
 
 class AuthorityController extends Controller
 {
@@ -82,7 +80,6 @@ class AuthorityController extends Controller
             
             // store translatable attributes
             foreach (\Config::get('translatable.locales') as $i=>$locale) {
-                // here I think it's only getting sk locale
                 foreach ($authority->translatedAttributes as $attribute) {
                     $authority->translateOrNew($locale)->$attribute = Input::get($locale . '.' . $attribute);
                 }

--- a/app/Http/Controllers/AuthorityController.php
+++ b/app/Http/Controllers/AuthorityController.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Facades\File;
 use App\SpiceHarvesterRecord;
 use Illuminate\Support\Facades\App;
 
+use Illuminate\Support\Facades\Log;
+
+
 class AuthorityController extends Controller
 {
 
@@ -76,11 +79,21 @@ class AuthorityController extends Controller
 
             // not sure if OK to fill all input like this before setting translated attributes
             $authority->fill($input);
+            Log::debug($input);
 
             // store translatable attributes
             foreach (\Config::get('translatable.locales') as $i=>$locale) {
+                // here I think it's only getting sk locale
                 foreach ($authority->translatedAttributes as $attribute) {
-                    $authority->translateOrNew($locale)->$attribute = Input::get($locale . '.' . $attribute);
+                    Log::debug($locale);
+                    Log::debug($attribute);
+                    Log::debug(Input::get($locale . '.' . $attribute));
+                    if ($attribute == 'birth_place') {
+                        $authority->translateOrNew($locale)->$attribute = Input::get($attribute);
+                    } else {
+                        $authority->translateOrNew($locale)->$attribute = Input::get($locale . '.' . $attribute);
+                        
+                    }
                 }
             }
 

--- a/app/Http/Controllers/AuthorityController.php
+++ b/app/Http/Controllers/AuthorityController.php
@@ -79,21 +79,12 @@ class AuthorityController extends Controller
 
             // not sure if OK to fill all input like this before setting translated attributes
             $authority->fill($input);
-            Log::debug($input);
-
+            
             // store translatable attributes
             foreach (\Config::get('translatable.locales') as $i=>$locale) {
                 // here I think it's only getting sk locale
                 foreach ($authority->translatedAttributes as $attribute) {
-                    Log::debug($locale);
-                    Log::debug($attribute);
-                    Log::debug(Input::get($locale . '.' . $attribute));
-                    if ($attribute == 'birth_place') {
-                        $authority->translateOrNew($locale)->$attribute = Input::get($attribute);
-                    } else {
-                        $authority->translateOrNew($locale)->$attribute = Input::get($locale . '.' . $attribute);
-                        
-                    }
+                    $authority->translateOrNew($locale)->$attribute = Input::get($locale . '.' . $attribute);
                 }
             }
 

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -70,7 +70,7 @@
             <div role="tabpanel" class="tab-pane  {{ ($i==0) ? 'active' : '' }}" id="{{ $locale }}">
               <div class="form-group">
                 {!! Form::label($locale . "[birth_place]", 'Miesto narodenia '.strtoupper($locale)) !!}
-                {!! Form::text($locale . "[birth_place]", Input::old($locale . "[birth_place]"), array('class' => 'form-control')) !!}
+                {!! Form::text($locale . "[birth_place]", @$authority->translate($locale)->birth_place : '', array('class' => 'form-control')) !!}
               </div>
               <div class="form-group">
                 {{ Form::label($locale . "[biography]", 'Biografia '.strtoupper($locale)) }}

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -70,7 +70,7 @@
             <div role="tabpanel" class="tab-pane  {{ ($i==0) ? 'active' : '' }}" id="{{ $locale }}">
               <div class="form-group">
                 {!! Form::label($locale . "[birth_place]", 'Miesto narodenia '.strtoupper($locale)) !!}
-                {!! Form::text($locale . "[birth_place]", @$authority->translate($locale)->birth_place : '', array('class' => 'form-control')) !!}
+                {!! Form::text($locale . "[birth_place]", isset($authority) ? @$authority->translate($locale)->birth_place : '', array('class' => 'form-control')) !!}
               </div>
               <div class="form-group">
                 {{ Form::label($locale . "[biography]", 'Biografia '.strtoupper($locale)) }}

--- a/resources/views/authorities/form.blade.php
+++ b/resources/views/authorities/form.blade.php
@@ -68,7 +68,10 @@
           <div class="tab-content top-space">
             @foreach (\Config::get('translatable.locales') as $i=>$locale)
             <div role="tabpanel" class="tab-pane  {{ ($i==0) ? 'active' : '' }}" id="{{ $locale }}">
-
+              <div class="form-group">
+                {!! Form::label($locale . "[birth_place]", 'Miesto narodenia '.strtoupper($locale)) !!}
+                {!! Form::text($locale . "[birth_place]", Input::old($locale . "[birth_place]"), array('class' => 'form-control')) !!}
+              </div>
               <div class="form-group">
                 {{ Form::label($locale . "[biography]", 'Biografia '.strtoupper($locale)) }}
                 {{ Form::textarea($locale . "[biography]", isset($authority) ? @$authority->translate($locale)->biography : '', array('class' => 'form-control wysiwyg', 'rows'=>'12')) }}
@@ -128,16 +131,10 @@
           {!! Form::text('studied_at', Input::old('studied_at'), array('class' => 'form-control')) !!}
         </div>
       </div>
-      <div class="col-md-6">
+      <div class="col-md-12">
         <div class="form-group">
           {!! Form::label('birth_year', 'Dátum narodenia (rok)') !!}
           {!! Form::text('birth_year', Input::old('birth_year'), array('class' => 'form-control')) !!}
-        </div>
-      </div>
-      <div class="col-md-6">
-        <div class="form-group">
-          {!! Form::label('birth_place', 'Miesto narodenia') !!}
-          {!! Form::text('birth_place', Input::old('birth_place'), array('class' => 'form-control')) !!}
         </div>
       </div>
       <div class="col-md-12">


### PR DESCRIPTION
# Description
adds separate form fields in admin for birth place (sk) and birth place (en), this way as long as the khb curators update the birth place for each locale using the admin (eg 'Londyn' and 'London') the birth place can be displayed in authority detail

Fixes #880 (link to Jira or GitHub issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have requested at least 1 reviewer for this PR
