### PR TITLE
WEBUMENIA-879 delete all image thumbnails before downloading new

### DIFF
--- a/app/Harvest/Harvesters/ItemHarvester.php
+++ b/app/Harvest/Harvesters/ItemHarvester.php
@@ -73,6 +73,7 @@ class ItemHarvester extends AbstractHarvester
      * @param Item $item
      */
     protected function downloadImages(Item $item) {
+        $item->deleteImage();
         foreach ($item->images as $image) {
             if (!$image->img_url) {
                 continue;


### PR DESCRIPTION
# Description

Delete all image thumbnails before downloading new in Item Harvest.

Fixes WEBUMENIA-879

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
