### PR TITLE
display extended title in gallery of artworks in authroity detail

### DIFF
--- a/app/Item.php
+++ b/app/Item.php
@@ -818,16 +818,14 @@ class Item extends Model
         return implode(', ', $this->authors)  . $dash .  $this->title;
     }
 
-    public function getFullTitle($html = false)
+    public function getSubTitle($html = false)
     {
         $separator = ', ';
         $title_parts = [
-            implode($separator, $this->authors),
-            $this->title,
             $this->getDatingFormated(),
             implode($separator, $this->techniques),
             implode($separator, $this->measurements),
-            $this->gallery,
+            // $this->gallery, // @TODO: temporarily exclude gallery because now in case of KHB gallery!=owner
         ];
         return implode($separator, array_filter($title_parts));
     }

--- a/app/Item.php
+++ b/app/Item.php
@@ -818,6 +818,20 @@ class Item extends Model
         return implode(', ', $this->authors)  . $dash .  $this->title;
     }
 
+    public function getFullTitle($html = false)
+    {
+        $separator = ', ';
+        $title_parts = [
+            implode($separator, $this->authors),
+            $this->title,
+            $this->getDatingFormated(),
+            implode($separator, $this->techniques),
+            implode($separator, $this->measurements),
+            $this->gallery,
+        ];
+        return implode($separator, array_filter($title_parts));
+    }
+
     public function getZoomableImages()
     {
         return $this->images->filter(function (ItemImage $image) {

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -118,7 +118,9 @@
                             <div id="iso">
                             @foreach ($items as $i=>$item)
                                 <div class="col-md-3 col-sm-4 col-xs-6 item border-0">
-                                    <a href="{!! $item->getImagePath() !!}" title="{!! $item->getTitleWithAuthors() !!}" data-photo-credit="{{ $item->photo_credit or 'Unknown'}}">
+                                    <a href="{!! $item->getImagePath() !!}"
+                                       title="{!! $item->getFullTitle() !!}"
+                                       data-photo-credit="{{ $item->photo_credit }}">
                                         @php
                                             list($width, $height) = getimagesize(public_path() . $item->getImagePath());
                                         @endphp
@@ -230,7 +232,11 @@
             image: {
                 tError: '<a href="%url%">The image #%curr%</a> could not be loaded.',
                 titleSrc: function(item) {
-                    return item.el.attr('title') + '<small>{{ trans('autor.by') }} '+ item.el.attr('data-photo-credit') +'</small>';
+                    var title = item.el.attr('title');
+                    if (item.el.attr('data-photo-credit')) {
+                        title = title + '<small>{{ trans('autor.by') }} '+ item.el.attr('data-photo-credit') +'</small>';
+                    }
+                    return title;
                 }
             }
         });

--- a/resources/views/autor.blade.php
+++ b/resources/views/autor.blade.php
@@ -119,7 +119,8 @@
                             @foreach ($items as $i=>$item)
                                 <div class="col-md-3 col-sm-4 col-xs-6 item border-0">
                                     <a href="{!! $item->getImagePath() !!}"
-                                       title="{!! $item->getFullTitle() !!}"
+                                       title="{!! $item->getTitleWithAuthors() !!}"
+                                       data-sub-title="{{ $item->getSubTitle() }}"
                                        data-photo-credit="{{ $item->photo_credit }}">
                                         @php
                                             list($width, $height) = getimagesize(public_path() . $item->getImagePath());
@@ -233,6 +234,9 @@
                 tError: '<a href="%url%">The image #%curr%</a> could not be loaded.',
                 titleSrc: function(item) {
                     var title = item.el.attr('title');
+                    if (item.el.attr('data-sub-title')) {
+                        title = title + '<small>'+ item.el.attr('data-sub-title') +'</small>';
+                    }
                     if (item.el.attr('data-photo-credit')) {
                         title = title + '<small>{{ trans('autor.by') }} '+ item.el.attr('data-photo-credit') +'</small>';
                     }


### PR DESCRIPTION
# Description

Display extended title in gallery of artworks in authority detail to include:
```
Autor, Názov, Datovanie, Technika, Miery, Galéria, Od: "Autor fotografie"
```

Including fix to display `photo_credit` only if is set.

Fixes WEBUMENIA-872

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [x] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
