### PR TITLE
display only work_types in subtitle in artworks gallery in authority detail

### DIFF
--- a/app/Item.php
+++ b/app/Item.php
@@ -821,9 +821,10 @@ class Item extends Model
     public function getSubTitle($html = false)
     {
         $separator = ', ';
+        $separator_hierarchical = ' &rsaquo; ';
         $title_parts = [
             $this->getDatingFormated(),
-            implode(' &rsaquo; ', array_unique($this->work_types)),
+            implode($separator_hierarchical, array_unique($this->work_types)),
             // implode($separator, $this->techniques),
             // implode($separator, $this->measurements),
             // $this->gallery, // @TODO: temporarily exclude gallery because now in case of KHB gallery!=owner

--- a/app/Item.php
+++ b/app/Item.php
@@ -823,8 +823,9 @@ class Item extends Model
         $separator = ', ';
         $title_parts = [
             $this->getDatingFormated(),
-            implode($separator, $this->techniques),
-            implode($separator, $this->measurements),
+            implode(' &rsaquo; ', array_unique($this->work_types)),
+            // implode($separator, $this->techniques),
+            // implode($separator, $this->measurements),
             // $this->gallery, // @TODO: temporarily exclude gallery because now in case of KHB gallery!=owner
         ];
         return implode($separator, array_filter($title_parts));


### PR DESCRIPTION
# Description

display only work_types in subtitle in artworks gallery in authority detail
without duplicated work_types

Fixes WEBUMENIA-872

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
