### PR TITLE
add exif extension to docker-php-ext-install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
 	gd \
 	mcrypt \
 	zip \
-    exif
+	exif
 
 RUN chown -R www-data:www-data /var/www
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
 	pdo_mysql \
 	gd \
 	mcrypt \
-	zip
+	zip \
+    exif
 
 RUN chown -R www-data:www-data /var/www
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM php:5.6-fpm
 
 RUN apt-get update -y && apt-get install -y \
-	libmcrypt-dev \
-	libpng-dev \
-	libjpeg-dev
+    libmcrypt-dev \
+    libpng-dev \
+    libjpeg-dev
 
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
-	&& docker-php-ext-install \
-	pdo_mysql \
-	gd \
-	mcrypt \
-	zip \
-	exif
+    && docker-php-ext-install \
+    pdo_mysql \
+    gd \
+    mcrypt \
+    zip \
+    exif
 
 RUN chown -R www-data:www-data /var/www
 


### PR DESCRIPTION
# Description

Fix exif_imagetype() bug by adding php extension in Dockerfile.
see: https://github.com/docker-library/php/issues/362#issuecomment-353686518

![screenshot 2019-02-05 at 12 47 02 pm](https://user-images.githubusercontent.com/902958/52280007-228dec80-295b-11e9-8c93-7329833ae073.png)

Rebuild docker containers to take effect:
`docker-compose build`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [X] I have requested at least 1 reviewer for this PR
- [ ] I have made corresponding changes to the documentation
